### PR TITLE
Fix sha256

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ package:
 source:
   fn: matplotlib-{{ version }}.tar.gz
   url: https://github.com/matplotlib/matplotlib/archive/v{{ version }}.tar.gz
-  sha256: 14c542780bf44db68b219e2e45c5a8de2c1fe308eea7f78c244b9b9d3923e09b
-
+  sha256: c334c5dccda790423e1e6ebc5a9a442aa2423894cfea08e62c5fd0116e40d9ae
   patches:
     # Find Tcl and libpng on Windows.
     - setupext.patch  # [win]


### PR DESCRIPTION
Not sure what happened here. In #37 the CIs passed with the `sha256` @tacaswell added, but once merged the conda accused a [mismatch](https://travis-ci.org/conda-forge/matplotlib-feedstock/jobs/142048253#L486) and I had to re-calculate the checksum.