### PR TITLE
Use the `toolchain` to build

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# FIXME: This is a hack to make sure the environment is activated.
+# The reason this is required is due to the conda-build issue
+# mentioned below.
+#
+# https://github.com/conda/conda-build/issues/910
+#
+source activate "${CONDA_DEFAULT_ENV}"
+
+
 if [ `uname` == Linux ]; then
     pushd $PREFIX/lib
     ln -s libtcl8.5.so libtcl.so

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,11 +20,12 @@ source:
     - rctmp_pyside.patch  # [not osx]
 
 build:
-    number: 3  # [not linux]
-    number: 4  # [linux]
+    number: 4  # [not linux]
+    number: 5  # [linux]
 
 requirements:
   build:
+    - toolchain
     - python
     - setuptools
     - pkg-config  # [not win]


### PR DESCRIPTION
Fixes https://github.com/conda-forge/matplotlib-feedstock/issues/39

So, `matplotlib` was not using the `toolchain` previously (has been around for quite awhile), but has C++ code. As discussed in this issue ( https://github.com/conda-forge/conda-forge.github.io/issues/183 ), we need to be using `libc++` on Mac. However, it appears some shadowing is happening additionally as suggested by this report ( https://github.com/conda-forge/matplotlib-feedstock/issues/39 ). This switches `matplotlib` over to `libc++` and thus should resolve these issues.