### PR TITLE
ENH: Disable check for framework Python in OSX backend.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,9 +18,11 @@ source:
     - cfg_qt4agg.patch  # [linux]
     # Patches the matplotlibrc template to default to Qt4.
     - rctmp_pyside.patch  # [not osx]
+    # Removes framework check from osx backend (seems unneeded)
+    - osx-frame.patch  # [osx]
 
 build:
-    number: 4
+    number: 5
 
 requirements:
   build:
@@ -60,7 +62,7 @@ requirements:
 test:
     imports:
         - matplotlib
-        - matplotlib.pyplot  # [not osx]
+        - matplotlib.pyplot
         - matplotlib._cntr
         - matplotlib._delaunay
         - matplotlib._image
@@ -72,10 +74,7 @@ test:
         - matplotlib.ttconv
         - matplotlib.backends._tkagg  # [not win]
         - mpl_toolkits
-        - pylab  # [not osx]
-    commands:
-        - pythonw -c "import matplotlib.pyplot"  # [osx]
-        - pythonw -c "import pylab"  # [osx]
+        - pylab
 
 about:
   home: http://matplotlib.org/

--- a/recipe/osx-frame.patch
+++ b/recipe/osx-frame.patch
@@ -1,0 +1,18 @@
+diff --git src/_macosx.m src/_macosx.m
+index 58b78ac..45c2d71 100644
+--- src/_macosx.m
++++ src/_macosx.m
+@@ -6348,13 +6348,6 @@ void init_macosx(void)
+ 
+     NSApp = [NSApplication sharedApplication];
+ 
+-    if (!verify_framework())
+-#if PY3K
+-        return NULL;
+-#else
+-        return;
+-#endif
+-
+ #if PY3K
+     module = PyModule_Create(&moduledef);
+     if (module==NULL) return NULL;


### PR DESCRIPTION
Without this check, the osx backend can be used with just `python`
rather than requiring `pythonw`. `pythonw` still works better (window
comes to the front and gives a taskbar icon), but not requiring
`pythonw` is much less surprising to users.

Since we now work with just python, simplify the tests.