### PR TITLE
Update ICU pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     - osx-frame.patch  # [osx]
 
 build:
-    number: 1
+  number: 2
 
 requirements:
   build:
@@ -31,7 +31,7 @@ requirements:
     - pkg-config  # [not win]
     - numpy x.x
     - python-dateutil
-    - freetype 2.6.*
+    - freetype 2.7|2.7.*
     - msinttypes  # [win]
     - cycler >=0.10
     - nose
@@ -44,14 +44,14 @@ requirements:
     - tk 8.5.*  # [linux]
     - functools32  # [py2k]
     - subprocess32  # [py2k and unix]
-    - icu 56.*  # [linux]
+    - icu 58.*  # [linux]
   run:
     - python
     - setuptools
     - numpy x.x
     - cycler >=0.10
     - python-dateutil
-    - freetype 2.6.*
+    - freetype 2.7|2.7.*
     - pytz
     - pyparsing
     #- py2cairo  # [linux and py2k]
@@ -60,7 +60,7 @@ requirements:
     - tk 8.5.*  # [linux]
     - functools32  # [py2k]
     - subprocess32  # [py2k and unix]
-    - icu 56.*  # [linux]
+    - icu 58.*  # [linux]
     - tornado
 
 test:
@@ -79,6 +79,9 @@ test:
     - matplotlib.backends._tkagg  # [not win]
     - mpl_toolkits
     - pylab
+  commands:
+    - conda inspect linkages -p $PREFIX matplotlib  # [not win]
+    - conda inspect objects -p $PREFIX matplotlib  # [osx]
 
 about:
   home: http://matplotlib.org/


### PR DESCRIPTION
Locally I get:

```shell
+ conda inspect linkages -p /opt/conda/conda-bld/recipe_1485976032748/_t_env matplotlib
matplotlib
----------

conda-forge::python-3.5.3-0:
    libpython3.5m.so.1.0 (lib/libpython3.5m.so.1.0)

conda-forge::zlib-1.2.11-0:
    libz.so.1 (lib/libz.so.1)

local::freetype-2.7-1:
    libfreetype.so.6 (lib/libfreetype.so.6)

local::libpng-1.6.28-0:
    libpng16.so.16 (lib/libpng16.so.16)

system:
    libc.so.6 (/lib64/libc.so.6)
    libdl.so.2 (/lib64/libdl.so.2)
    libgcc_s.so.1 (/lib64/libgcc_s.so.1)
    libm.so.6 (/lib64/libm.so.6)
    libpthread.so.0 (/lib64/libpthread.so.0)
    librt.so.1 (/lib64/librt.so.1)
    libstdc++.so.6 (/usr/lib64/libstdc++.so.6)
    libutil.so.1 (/lib64/libutil.so.1)
    linux-vdso.so.1 ()

not found:


TEST END: matplotlib-2.0.0-np112py35_2
```

I guess that `icu` is not needed. Maybe it was added to force the right version but that should not be done in `matplotlib`. I will investigate this further. (I suspect `fontconfig` was the culprit at the time when `icu` was added here.)