### PR TITLE
Use matplotlib's built-in freetype

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,4 +61,4 @@ install:
 script:
   - conda build ./recipe
 
-  - upload_or_check_non_existence ./recipe conda-forge --channel=main
+  - upload_or_check_non_existence ./recipe conda-forge --channel=testing

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -113,4 +113,4 @@ build: off
 test_script:
     - "%CMD_IN_ENV% conda build recipe --quiet"
 deploy_script:
-    - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main
+    - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=testing

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -49,42 +49,42 @@ source run_conda_forge_build_setup
     export CONDA_PY=27
     set +x
     conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=testing || exit 1
 
     set -x
     export CONDA_NPY=112
     export CONDA_PY=27
     set +x
     conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=testing || exit 1
 
     set -x
     export CONDA_NPY=111
     export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=testing || exit 1
 
     set -x
     export CONDA_NPY=112
     export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=testing || exit 1
 
     set -x
     export CONDA_NPY=111
     export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=testing || exit 1
 
     set -x
     export CONDA_NPY=112
     export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=testing || exit 1
 touch /feedstock_root/build_artefacts/conda-forge-build-done
 EOF
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,6 @@ travis:
 appveyor:
   secure:
     BINSTAR_TOKEN: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
+channels:
+  targets:
+    - [conda-forge, testing]

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,6 +8,8 @@ ECHO [packages] >> setup.cfg
 ECHO tests = False >> setup.cfg
 ECHO sample_data = False >> setup.cfg
 ECHO toolkits_tests = False >> setup.cfg
+ECHO [test] >> setup.cfg
+ECHO local_freetype = True >> setup.cfg
 
 %PYTHON% setup.py install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,6 +16,9 @@ tests = False
 toolkit_tests = False
 sample_data = False
 
+[test]
+local_freetype = True
+
 EOF
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,8 @@ source:
 
 build:
   number: 0
+  # Won't work until Matplotlib 2.1 where setupext.py can use local freetype on win
+  skip: True  # [win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     - pkg-config  # [not win]
     - numpy x.x
     - python-dateutil
-    - freetype 2.7|2.7.*
     - msinttypes  # [win]
     - cycler >=0.10
     - nose
@@ -49,7 +48,6 @@ requirements:
     - numpy x.x
     - cycler >=0.10
     - python-dateutil
-    - freetype 2.7|2.7.*
     - pytz
     - pyparsing
     #- py2cairo  # [linux and py2k]


### PR DESCRIPTION
This is against the `testing` branch I just added. If everything works properly, this should result in new packages for the conda-forge/label/testing channel, with matplotlib built using its `local_freetype=True` setting.

Closes #110.