### PR TITLE
Bump to build number 2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - osx-frame.patch  # [osx]
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/matplotlib-feedstock/issues/138

Appears the some new `gcc` libraries slipped in during the build of `matplotlib`. The result is that it got linked to these and became dependent on them. Looks like the cause is some packages coming from `defaults`. Namely `python` and `readline`. This is due to the fact that `python` 2.7 and `python` 3.5 were not dependent on `readline` 7.0 yet. However that has since been fixed. Hence this should be resolved with a simple rebuild.