### PR TITLE
Make testing packages work on Windows and Python 3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,22 @@ environment:
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
+    - TARGET_ARCH: x86
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,8 @@
 set LIB=%LIBRARY_LIB%;%LIB%
 set LIBPATH=%LIBRARY_LIB%;%LIBPATH%
 set INCLUDE=%LIBRARY_INC%;%INCLUDE%
+rem Resolves MSB4175: The task factory "CodeTaskFactory" could not be loaded from the assembly
+set VisualStudioVersion=
 
 ECHO [directories] > setup.cfg
 ECHO basedirlist = %LIBRARY_PREFIX% >> setup.cfg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ source:
 
 build:
   number: 200
-  skip: True  # [win and (py35 or py36)]
 
 requirements:
   build:

--- a/recipe/setupext.patch
+++ b/recipe/setupext.patch
@@ -1,6 +1,17 @@
 --- setupext.py
 +++ setupext.py
-@@ -998,7 +998,7 @@ class Png(SetupPackage):
+@@ -1229,9 +1229,9 @@ echo Build completed, moving result"
+ :: move to the "normal" path for the unix builds...
+ mkdir %FREETYPE%\\objs\\.libs
+ :: REMINDER: fix when changing the version
+-copy %FREETYPE%\\objs\\{vc20xx}\\{xXX}\\freetype261.lib %FREETYPE%\\objs\\.libs\\libfreetype.lib
++copy %FREETYPE%\\objs\\{vc20xx}\\{WinXX}\\freetype261.lib %FREETYPE%\\objs\\.libs\\libfreetype.lib
+ if errorlevel 1 (
+   rem This is a py27 version, which has a different location for the lib file :-/
+   copy %FREETYPE%\\objs\\win32\\{vc20xx}\\freetype261.lib %FREETYPE%\\objs\\.libs\\libfreetype.lib
+ )
+ """
+@@ -1307,7 +1307,7 @@ class Png(SetupPackage):
              ]
          ext = make_extension('matplotlib._png', sources)
          pkg_config.setup_extension(


### PR DESCRIPTION
Supersedes #149. This should work, and hopefully AppVeyor finds us now.