### PR TITLE
 Require backports.functools_lru_cache on Python 2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - python
     - setuptools
     - pkg-config  # [not win]
-    - backports.functools_lru_cache
+    - backports.functools_lru_cache  # [py2k]
     - numpy 1.8.*  # [not (win and (py35 or py36))]
     - numpy 1.9.*  # [win and py35]
     - numpy 1.11.*  # [win and py36]
@@ -52,7 +52,7 @@ requirements:
     - numpy >=1.9  # [win and py35]
     - numpy >=1.11  # [win and py36]
     - setuptools
-    - backports.functools_lru_cache
+    - backports.functools_lru_cache  # [py2k]
     - cycler >=0.10
     - python-dateutil
     - freetype 2.8.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - osx-frame.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Previously `backports.functools_lru_cache` was being installed on Python 2 and Python 3. However, as it is a backports package, it should not be needed on Python 3, which has also been confirmed. This adds a selector to only require `backports.functools_lru_cache` on Python 2 and not Python 3.

cc @tacaswell

xref: https://github.com/conda-forge/matplotlib-feedstock/pull/132