### PR TITLE
Do not require setuptools twice

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - osx-frame.patch  # [osx]
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -51,7 +51,6 @@ requirements:
     - numpy >=1.8  # [not (win and (py35 or py36))]
     - numpy >=1.9  # [win and py35]
     - numpy >=1.11  # [win and py36]
-    - setuptools
     - backports.functools_lru_cache  # [py2k]
     - cycler >=0.10
     - python-dateutil

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - osx-frame.patch  # [osx]
 
 build:
-  number: 2
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
I am a bit surprised that this needs setuptools at runtime, but I guess there is no point in stating that twice?