### PR TITLE
update checksum

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/matplotlib/matplotlib/archive/v{{ version }}.tar.gz
-  sha256: 8ad8e3521172922c2a3ac897ac2bee0349ef75286909a60150cfa4e774596827
+  sha256: da5b804222864a8e854ed68f16dcbc8b2fa096537d84f879cc8289db368735c8
   patches:
     # Find libpng on Windows.
     - setupext.patch  # [win]


### PR DESCRIPTION
@tacaswell now I get why your PR failed, the checksum changed, probably someone edit the release and GitHub updated it. I thought about pointing this to PyPI but I see there is no source tarball there yet, so we'll have to stick with GitHub.

PS: one alternative is to upload a source distribution tarball to GitHub, that won't change the checksum. (Numpy does that BTW.)