### PR TITLE
MNT: does not actually depend on pytz anymore

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - setupext.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<35]
 
 requirements:
@@ -33,7 +33,6 @@ requirements:
     - cycler >=0.10
     - nose
     - pyparsing
-    - pytz
     - libpng
     - zlib  # [win]
     - pyqt  # [not osx]
@@ -46,7 +45,6 @@ requirements:
     - cycler >=0.10
     - python-dateutil
     - freetype
-    - pytz
     - pyparsing
     - libpng
     - pyqt  # [not osx]


### PR DESCRIPTION
There will be a 3.0.1 in the next month or so, I think that this can
wait until then.


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->