### PR TITLE
manually start PyPy migration

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,16 +8,20 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_numpy1.19python3.7.____73_pypy:
-        CONFIG: linux_64_numpy1.19python3.7.____73_pypy
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_numpy1.19python3.7.____cpython:
         CONFIG: linux_64_numpy1.19python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_numpy1.19python3.8.____73_pypy:
+        CONFIG: linux_64_numpy1.19python3.8.____73_pypy
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_numpy1.19python3.8.____cpython:
         CONFIG: linux_64_numpy1.19python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_numpy1.19python3.9.____73_pypy:
+        CONFIG: linux_64_numpy1.19python3.9.____73_pypy
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_numpy1.19python3.9.____cpython:
@@ -28,16 +32,20 @@ jobs:
         CONFIG: linux_64_numpy1.21python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_numpy1.19python3.7.____73_pypy:
-        CONFIG: linux_aarch64_numpy1.19python3.7.____73_pypy
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_aarch64_numpy1.19python3.7.____cpython:
         CONFIG: linux_aarch64_numpy1.19python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_numpy1.19python3.8.____73_pypy:
+        CONFIG: linux_aarch64_numpy1.19python3.8.____73_pypy
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_aarch64_numpy1.19python3.8.____cpython:
         CONFIG: linux_aarch64_numpy1.19python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_numpy1.19python3.9.____73_pypy:
+        CONFIG: linux_aarch64_numpy1.19python3.9.____73_pypy
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_aarch64_numpy1.19python3.9.____cpython:
@@ -48,16 +56,20 @@ jobs:
         CONFIG: linux_aarch64_numpy1.21python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_numpy1.19python3.7.____73_pypy:
-        CONFIG: linux_ppc64le_numpy1.19python3.7.____73_pypy
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_numpy1.19python3.7.____cpython:
         CONFIG: linux_ppc64le_numpy1.19python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_numpy1.19python3.8.____73_pypy:
+        CONFIG: linux_ppc64le_numpy1.19python3.8.____73_pypy
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_numpy1.19python3.8.____cpython:
         CONFIG: linux_ppc64le_numpy1.19python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_numpy1.19python3.9.____73_pypy:
+        CONFIG: linux_ppc64le_numpy1.19python3.9.____73_pypy
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_numpy1.19python3.9.____cpython:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,14 +8,17 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_64_numpy1.19python3.7.____73_pypy:
-        CONFIG: osx_64_numpy1.19python3.7.____73_pypy
-        UPLOAD_PACKAGES: 'True'
       osx_64_numpy1.19python3.7.____cpython:
         CONFIG: osx_64_numpy1.19python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
+      osx_64_numpy1.19python3.8.____73_pypy:
+        CONFIG: osx_64_numpy1.19python3.8.____73_pypy
+        UPLOAD_PACKAGES: 'True'
       osx_64_numpy1.19python3.8.____cpython:
         CONFIG: osx_64_numpy1.19python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_numpy1.19python3.9.____73_pypy:
+        CONFIG: osx_64_numpy1.19python3.9.____73_pypy
         UPLOAD_PACKAGES: 'True'
       osx_64_numpy1.19python3.9.____cpython:
         CONFIG: osx_64_numpy1.19python3.9.____cpython

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,14 +8,17 @@ jobs:
     vmImage: windows-2019
   strategy:
     matrix:
-      win_64_numpy1.19python3.7.____73_pypy:
-        CONFIG: win_64_numpy1.19python3.7.____73_pypy
-        UPLOAD_PACKAGES: 'True'
       win_64_numpy1.19python3.7.____cpython:
         CONFIG: win_64_numpy1.19python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
+      win_64_numpy1.19python3.8.____73_pypy:
+        CONFIG: win_64_numpy1.19python3.8.____73_pypy
+        UPLOAD_PACKAGES: 'True'
       win_64_numpy1.19python3.8.____cpython:
         CONFIG: win_64_numpy1.19python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_numpy1.19python3.9.____73_pypy:
+        CONFIG: win_64_numpy1.19python3.9.____73_pypy
         UPLOAD_PACKAGES: 'True'
       win_64_numpy1.19python3.9.____cpython:
         CONFIG: win_64_numpy1.19python3.9.____cpython
@@ -28,45 +31,27 @@ jobs:
     CONDA_BLD_PATH: D:\\bld\\
 
   steps:
-    - script: |
-        choco install vcpython27 -fdv -y --debug
-      condition: contains(variables['CONFIG'], 'vs2008')
-      displayName: Install vcpython27.msi (if needed)
-
-    # Cygwin's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
-    # - script: rmdir C:\cygwin /s /q
-    #   continueOnError: true
-
-    - powershell: |
-        Set-PSDebug -Trace 1
-
-        $batchcontent = @"
-        ECHO ON
-        SET vcpython=C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0
-
-        DIR "%vcpython%"
-
-        CALL "%vcpython%\vcvarsall.bat" %*
-        "@
-
-        $batchDir = "C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0\VC"
-        $batchPath = "$batchDir" + "\vcvarsall.bat"
-        New-Item -Path $batchPath -ItemType "file" -Force
-
-        Set-Content -Value $batchcontent -Path $batchPath
-
-        Get-ChildItem -Path $batchDir
-
-        Get-ChildItem -Path ($batchDir + '\..')
-
-      condition: contains(variables['CONFIG'], 'vs2008')
-      displayName: Patch vs2008 (if needed)
-    - task: CondaEnvironment@1
+    - task: PythonScript@0
+      displayName: 'Download Miniforge'
       inputs:
-        packageSpecs: 'python=3.9 conda-build conda pip boa conda-forge-ci-setup=3' # Optional
-        installOptions: "-c conda-forge"
-        updateConda: true
-      displayName: Install conda-build and activate environment
+        scriptSource: inline
+        script: |
+          import urllib.request
+          url = 'https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Windows-x86_64.exe'
+          path = r"$(Build.ArtifactStagingDirectory)/Miniforge.exe"
+          urllib.request.urlretrieve(url, path)
+
+    - script: |
+        start /wait "" %BUILD_ARTIFACTSTAGINGDIRECTORY%\Miniforge.exe /InstallationType=JustMe /RegisterPython=0 /S /D=C:\Miniforge
+      displayName: Install Miniforge
+
+    - powershell: Write-Host "##vso[task.prependpath]C:\Miniforge\Scripts"
+      displayName: Add conda to PATH
+
+    - script: |
+        call activate base
+        mamba.exe install 'python=3.9' conda-build conda pip boa 'conda-forge-ci-setup=3' -c conda-forge --strict-channel-priority --yes
+      displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1
       displayName: Set PYTHONUNBUFFERED
@@ -83,25 +68,16 @@ jobs:
         call activate base
         run_conda_forge_build_setup
       displayName: conda-forge build setup
-    
-
-    # Special cased version setting some more things!
-    - script: |
-        call activate base
-        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
-      displayName: Build recipe (vs2008)
-      env:
-        VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
-        PYTHONUNBUFFERED: 1
-      condition: contains(variables['CONFIG'], 'vs2008')
 
     - script: |
         call activate base
+        if EXIST LICENSE.txt (
+          copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
+        )
         conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1
-      condition: not(contains(variables['CONFIG'], 'vs2008'))
     - script: |
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
         call activate base

--- a/.ci_support/linux_64_numpy1.19python3.8.____73_pypy.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.8.____73_pypy.yaml
@@ -1,11 +1,19 @@
 c_compiler:
-- vs2017
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2017
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 freetype:
 - '2'
 numpy:
@@ -16,13 +24,19 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  tk:
+    max_pin: x.x
 python:
-- 3.7.* *_73_pypy
+- 3.8.* *_73_pypy
 python_impl:
 - pypy
 target_platform:
-- win-64
+- linux-64
+tk:
+- '8.6'
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - python
   - numpy
   - python_impl

--- a/.ci_support/linux_64_numpy1.19python3.9.____73_pypy.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____73_pypy.yaml
@@ -1,0 +1,42 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+freetype:
+- '2'
+numpy:
+- '1.19'
+pin_run_as_build:
+  freetype:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  tk:
+    max_pin: x.x
+python:
+- 3.9.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- linux-64
+tk:
+- '8.6'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.19python3.8.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.8.____73_pypy.yaml
@@ -1,0 +1,46 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+freetype:
+- '2'
+numpy:
+- '1.19'
+pin_run_as_build:
+  freetype:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  tk:
+    max_pin: x.x
+python:
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- linux-aarch64
+tk:
+- '8.6'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.19python3.9.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.9.____73_pypy.yaml
@@ -1,0 +1,46 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+freetype:
+- '2'
+numpy:
+- '1.19'
+pin_run_as_build:
+  freetype:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  tk:
+    max_pin: x.x
+python:
+- 3.9.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- linux-aarch64
+tk:
+- '8.6'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy
+  - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.19python3.8.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.19python3.8.____73_pypy.yaml
@@ -1,11 +1,7 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '10'
-cdt_arch:
-- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -28,16 +24,12 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
-  tk:
-    max_pin: x.x
 python:
-- 3.7.* *_73_pypy
+- 3.8.* *_73_pypy
 python_impl:
 - pypy
 target_platform:
-- linux-aarch64
-tk:
-- '8.6'
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_numpy1.19python3.9.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.19python3.9.____73_pypy.yaml
@@ -1,23 +1,21 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-MACOSX_SDK_VERSION:
-- '10.11'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '13'
+- '10'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '13'
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 freetype:
 - '2'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
 - '1.19'
 pin_run_as_build:
@@ -27,11 +25,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.* *_73_pypy
+- 3.9.* *_73_pypy
 python_impl:
 - pypy
 target_platform:
-- osx-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/migrations/pypy38.yaml
+++ b/.ci_support/migrations/pypy38.yaml
@@ -1,0 +1,53 @@
+migrator_ts: 1647123563
+__migrator:
+    migration_number: 1
+    primary_key: python
+    ordering:
+        python:
+            - 3.6.* *_cpython
+            - 3.7.* *_cpython
+            - 3.8.* *_cpython
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.6.* *_73_pypy
+            - 3.7.* *_73_pypy
+            - 3.8.* *_73_pypy
+            - 3.9.* *_73_pypy
+    paused: False
+    longterm: True
+    use_local: False
+    check_solvable: True
+    exclude_pinned_pkgs: False
+    pr_limit: 1
+    bump_number: 1
+    wait_for_migrators:
+      - python310
+    commit_message: "Rebuild for PyPy3.8 and PyPy3.9"
+    exclude:
+      # this shouldn't attempt to modify the python feedstocks
+      - python
+      - pypy3.6
+      - pypy-meta
+
+python:
+  - 3.7.* *_cpython    # [not (osx and arm64)]
+  - 3.8.* *_cpython
+  - 3.9.* *_cpython
+  - 3.10.* *_cpython
+  - 3.8.* *_73_pypy    # [not (osx and arm64)]
+  - 3.9.* *_73_pypy    # [not (osx and arm64)]
+numpy:
+  # part of a zip_keys: python, python_impl, numpy
+  - 1.19               # [not (osx and arm64)]
+  - 1.19
+  - 1.19
+  - 1.21
+  - 1.22               # [not (osx and arm64)]
+  - 1.22               # [not (osx and arm64)]
+python_impl:
+  - cpython            # [not (osx and arm64)]
+  - cpython
+  - cpython
+  - cpython
+  - pypy               # [not (osx and arm64)]
+  - pypy               # [not (osx and arm64)]

--- a/.ci_support/osx_64_numpy1.19python3.8.____73_pypy.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.8.____73_pypy.yaml
@@ -1,0 +1,40 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+MACOSX_SDK_VERSION:
+- '10.11'
+c_compiler:
+- clang
+c_compiler_version:
+- '13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+freetype:
+- '2'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.19'
+pin_run_as_build:
+  freetype:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.19python3.9.____73_pypy.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.9.____73_pypy.yaml
@@ -1,21 +1,23 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+MACOSX_SDK_VERSION:
+- '10.11'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '10'
-cdt_name:
-- cos6
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '10'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '13'
 freetype:
 - '2'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
 - '1.19'
 pin_run_as_build:
@@ -24,16 +26,12 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
-  tk:
-    max_pin: x.x
 python:
-- 3.7.* *_73_pypy
+- 3.9.* *_73_pypy
 python_impl:
 - pypy
 target_platform:
-- linux-64
-tk:
-- '8.6'
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/win_64_numpy1.19python3.8.____73_pypy.yaml
+++ b/.ci_support/win_64_numpy1.19python3.8.____73_pypy.yaml
@@ -1,0 +1,28 @@
+c_compiler:
+- vs2017
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2017
+freetype:
+- '2'
+numpy:
+- '1.19'
+pin_run_as_build:
+  freetype:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- win-64
+zip_keys:
+- - python
+  - numpy
+  - python_impl

--- a/.ci_support/win_64_numpy1.19python3.9.____73_pypy.yaml
+++ b/.ci_support/win_64_numpy1.19python3.9.____73_pypy.yaml
@@ -1,19 +1,11 @@
 c_compiler:
-- gcc
-c_compiler_version:
-- '10'
-cdt_name:
-- cos7
+- vs2017
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '10'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- vs2017
 freetype:
 - '2'
 numpy:
@@ -25,14 +17,12 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.* *_73_pypy
+- 3.9.* *_73_pypy
 python_impl:
 - pypy
 target_platform:
-- linux-ppc64le
+- win-64
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 - - python
   - numpy
   - python_impl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ version: 2
 jobs:
   build:
     working_directory: ~/test
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -24,7 +24,10 @@ export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 cat >~/.condarc <<CONDARC
 
 conda-build:
- root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+pkgs_dirs:
+  - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
+  - /opt/conda/pkgs
 
 CONDARC
 
@@ -56,6 +59,10 @@ fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null
+
+if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
+  cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
+fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -61,6 +61,10 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
 fi
 
 
+if [[ -f LICENSE.txt ]]; then
+  cp LICENSE.txt "recipe/recipe-scripts-license.txt"
+fi
+
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,27 @@
-BSD 3-clause license
+BSD-3-Clause license
 Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/README.md
+++ b/README.md
@@ -38,13 +38,6 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_numpy1.19python3.7.____73_pypy</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.19python3.7.____73_pypy" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_64_numpy1.19python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
@@ -52,10 +45,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_numpy1.19python3.8.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.19python3.8.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_numpy1.19python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.19python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_numpy1.19python3.9.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=linux&configuration=linux_64_numpy1.19python3.9.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -73,13 +80,6 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.19python3.7.____73_pypy</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.19python3.7.____73_pypy" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_aarch64_numpy1.19python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
@@ -87,10 +87,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_numpy1.19python3.8.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.19python3.8.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_aarch64_numpy1.19python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.19python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.19python3.9.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_numpy1.19python3.9.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -108,13 +122,6 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_numpy1.19python3.7.____73_pypy</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_numpy1.19python3.7.____73_pypy" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_ppc64le_numpy1.19python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
@@ -122,10 +129,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_ppc64le_numpy1.19python3.8.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_numpy1.19python3.8.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_ppc64le_numpy1.19python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_numpy1.19python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_numpy1.19python3.9.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_numpy1.19python3.9.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -143,13 +164,6 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.19python3.7.____73_pypy</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.19python3.7.____73_pypy" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>osx_64_numpy1.19python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
@@ -157,10 +171,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_64_numpy1.19python3.8.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.19python3.8.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_numpy1.19python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.19python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.19python3.9.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=osx&configuration=osx_64_numpy1.19python3.9.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -199,13 +227,6 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.19python3.7.____73_pypy</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=win&configuration=win_64_numpy1.19python3.7.____73_pypy" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>win_64_numpy1.19python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
@@ -213,10 +234,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>win_64_numpy1.19python3.8.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=win&configuration=win_64_numpy1.19python3.8.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64_numpy1.19python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=win&configuration=win_64_numpy1.19python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.19python3.9.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=617&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/matplotlib-feedstock?branchName=main&jobName=win&configuration=win_64_numpy1.19python3.9.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/build-locally.py
+++ b/build-locally.py
@@ -86,12 +86,19 @@ def main(args=None):
     verify_config(ns)
     setup_environment(ns)
 
-    if ns.config.startswith("linux") or (
-        ns.config.startswith("osx") and platform.system() == "Linux"
-    ):
-        run_docker_build(ns)
-    elif ns.config.startswith("osx"):
-        run_osx_build(ns)
+    try:
+        if ns.config.startswith("linux") or (
+            ns.config.startswith("osx") and platform.system() == "Linux"
+        ):
+            run_docker_build(ns)
+        elif ns.config.startswith("osx"):
+            run_osx_build(ns)
+    finally:
+        recipe_license_file = os.path.join(
+            "recipe", "recipe-scripts-license.txt"
+        )
+        if os.path.exists(recipe_license_file):
+            os.remove(recipe_license_file)
 
 
 if __name__ == "__main__":

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: c81325d1b0d822ef75fd71d243f98478cdca1f800a838a2a1bc8e4e17b8df93c
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: matplotlib-base


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The dependency resolver bot did not start the pypy3.8/3.9 migration because pyqt is a parent in the graph. But I think pyqt is an optional dependency, not a hard one. The PR works around the problem by manually adding the migration file.
