### PR TITLE
use libraqm-devel to avoid pkgconfig hacks

### DIFF
--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -18,8 +18,6 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 freetype:
 - '2'
-glib:
-- '2'
 numpy:
 - '2'
 pin_run_as_build:
@@ -39,5 +37,3 @@ tk:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -18,8 +18,6 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 freetype:
 - '2'
-glib:
-- '2'
 numpy:
 - '2'
 pin_run_as_build:
@@ -39,5 +37,3 @@ tk:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -18,8 +18,6 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 freetype:
 - '2'
-glib:
-- '2'
 numpy:
 - '2'
 pin_run_as_build:
@@ -39,5 +37,3 @@ tk:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/linux_64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_python3.14.____cp314.yaml
@@ -18,8 +18,6 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 freetype:
 - '2'
-glib:
-- '2'
 numpy:
 - '2'
 pin_run_as_build:
@@ -39,5 +37,3 @@ tk:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -18,8 +18,6 @@ docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma9
 freetype:
 - '2'
-glib:
-- '2'
 numpy:
 - '2'
 pin_run_as_build:
@@ -39,5 +37,3 @@ tk:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -18,8 +18,6 @@ docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma9
 freetype:
 - '2'
-glib:
-- '2'
 numpy:
 - '2'
 pin_run_as_build:
@@ -39,5 +37,3 @@ tk:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -18,8 +18,6 @@ docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma9
 freetype:
 - '2'
-glib:
-- '2'
 numpy:
 - '2'
 pin_run_as_build:
@@ -39,5 +37,3 @@ tk:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/linux_aarch64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_python3.14.____cp314.yaml
@@ -18,8 +18,6 @@ docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma9
 freetype:
 - '2'
-glib:
-- '2'
 numpy:
 - '2'
 pin_run_as_build:
@@ -39,5 +37,3 @@ tk:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -18,8 +18,6 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 freetype:
 - '2'
-glib:
-- '2'
 numpy:
 - '2'
 pin_run_as_build:
@@ -37,5 +35,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
@@ -18,8 +18,6 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 freetype:
 - '2'
-glib:
-- '2'
 numpy:
 - '2'
 pin_run_as_build:
@@ -37,5 +35,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
@@ -18,8 +18,6 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 freetype:
 - '2'
-glib:
-- '2'
 numpy:
 - '2'
 pin_run_as_build:
@@ -37,5 +35,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/linux_ppc64le_python3.14.____cp314.yaml
+++ b/.ci_support/linux_ppc64le_python3.14.____cp314.yaml
@@ -18,8 +18,6 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 freetype:
 - '2'
-glib:
-- '2'
 numpy:
 - '2'
 pin_run_as_build:
@@ -37,5 +35,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '19'
 freetype:
 - '2'
-glib:
-- '2'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
@@ -41,5 +39,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '19'
 freetype:
 - '2'
-glib:
-- '2'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
@@ -41,5 +39,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '19'
 freetype:
 - '2'
-glib:
-- '2'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
@@ -41,5 +39,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/osx_64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_64_python3.14.____cp314.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '19'
 freetype:
 - '2'
-glib:
-- '2'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
@@ -41,5 +39,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '19'
 freetype:
 - '2'
-glib:
-- '2'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:
@@ -41,5 +39,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '19'
 freetype:
 - '2'
-glib:
-- '2'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:
@@ -41,5 +39,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '19'
 freetype:
 - '2'
-glib:
-- '2'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:
@@ -41,5 +39,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/osx_arm64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '19'
 freetype:
 - '2'
-glib:
-- '2'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:
@@ -41,5 +39,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zlib:
-- '1'

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -10,8 +10,6 @@ cxx_compiler:
 - vs2022
 freetype:
 - '2'
-glib:
-- '2'
 numpy:
 - '2'
 pin_run_as_build:
@@ -26,5 +24,3 @@ qhull:
 - '2020.2'
 target_platform:
 - win-64
-zlib:
-- '1'

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -10,8 +10,6 @@ cxx_compiler:
 - vs2022
 freetype:
 - '2'
-glib:
-- '2'
 numpy:
 - '2'
 pin_run_as_build:
@@ -26,5 +24,3 @@ qhull:
 - '2020.2'
 target_platform:
 - win-64
-zlib:
-- '1'

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -10,8 +10,6 @@ cxx_compiler:
 - vs2022
 freetype:
 - '2'
-glib:
-- '2'
 numpy:
 - '2'
 pin_run_as_build:
@@ -26,5 +24,3 @@ qhull:
 - '2020.2'
 target_platform:
 - win-64
-zlib:
-- '1'

--- a/.ci_support/win_64_python3.14.____cp314.yaml
+++ b/.ci_support/win_64_python3.14.____cp314.yaml
@@ -10,8 +10,6 @@ cxx_compiler:
 - vs2022
 freetype:
 - '2'
-glib:
-- '2'
 numpy:
 - '2'
 pin_run_as_build:
@@ -26,5 +24,3 @@ qhull:
 - '2020.2'
 target_platform:
 - win-64
-zlib:
-- '1'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 58723eaaa7d38b26fca940b537a26c5d14ebd87c60a5685e32299b55587fe561
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<311]
 
 # to avoid creating redundant CI jobs, conda-smithy needs python
@@ -25,10 +25,6 @@ outputs:
   - name: matplotlib-base
     script: build_base.bat  # [win]
     script: build_base.sh  # [not win]
-    build:
-      ignore_run_exports_from:
-        - glib
-        - zlib
     requirements:
       build:
         - python                                 # [build_platform != target_platform]
@@ -50,11 +46,8 @@ outputs:
         - certifi >=2020.06.20
         - pybind11 >=2.13.2,!=2.13.3
         - freetype
-        - libraqm
+        - libraqm-devel
         - qhull
-        # freetype.pc requires zlib.pc, libraqm requires glib
-        - glib  # [win]
-        - zlib
         - numpy
         - setuptools >=64
         - setuptools_scm >=7


### PR DESCRIPTION
This is a delayed clean-up for 998b7b1a760b6a75eaf6efaefee3279edb2cf161 (since #439 was merged already and https://github.com/conda-forge/libraqm-feedstock/pull/3 was blocked on some other pkg-config clean-ups). 